### PR TITLE
EPOLLET should wake up for each eventfd write, even without reads

### DIFF
--- a/functional/Makefile
+++ b/functional/Makefile
@@ -6,7 +6,7 @@
 
 #
 # Copyright 2019 Joyent, Inc.
-# Copyright 2020 Oxide Computer Company
+# Copyright 2024 Oxide Computer Company
 #
 
 CFLAGS	= -fno-omit-frame-pointer
@@ -14,7 +14,7 @@ TESTS	= $(PLAIN_TESTS) $(THREAD_TESTS)
 PLAIN_TESTS	=	test_create test_depth1 test_depth2 test_dir test_file
 PLAIN_TESTS	+=	test_loop test_nested test_nested_et test_replace
 PLAIN_TESTS	+=	test_oneshot test_timeout test_errevent test_hupevent
-PLAIN_TESTS	+=	test_exclusive test_pipe_et
+PLAIN_TESTS	+=	test_exclusive test_pipe_et test_eventfd_et
 THREAD_TESTS	=	test_et
 COMMON	= common.o
 

--- a/functional/test_eventfd_et.c
+++ b/functional/test_eventfd_et.c
@@ -1,0 +1,74 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright 2024 Oxide Computer Company
+ */
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <sys/epoll.h>
+#include <sys/eventfd.h>
+
+#include "common.h"
+
+/*
+ * Some software makes use of an eventfd to wake up an event loop.
+ *
+ * On Linux systems, an edge-triggered wait on an eventfd descriptor will fire
+ * for every write, even if that descriptor has not been read after poll.
+ */
+int
+main(int argc, char **argv)
+{
+	int efd, evfd, res, err;
+	struct epoll_event ev;
+	eventfd_t val = 1;
+
+	test_init(argc, argv);
+
+	if ((evfd = eventfd(0, EFD_NONBLOCK)) == -1)
+		test_fatal("eventfd()");
+
+	if ((efd = epoll_create1(EPOLL_CLOEXEC)) < 0)
+		test_fatal("epoll_create1()");
+
+	ev.events = EPOLLIN|EPOLLRDHUP|EPOLLET;
+	ev.data.fd = evfd;
+	if (epoll_ctl(efd, EPOLL_CTL_ADD, evfd, &ev) < 0)
+		test_fatal("epoll_ctl(EPOLL_CTL_ADD)");
+
+	/*
+	 * No events should be pending to start
+	 */
+	test_equal(epoll_wait(efd, &ev, 1, 0), 0);
+
+	/*
+	 * Trigger a wake-up by writing 1
+	 */
+	if (eventfd_write(evfd, val) == -1)
+		test_fatal("eventfd_write()");
+
+	test_equal(epoll_wait(efd, &ev, 1, 0), 1);
+	test_equal(ev.events, EPOLLIN);
+	test_equal(ev.data.fd, evfd);
+
+	/*
+	 * Trigger another wake-up without having done a read
+	 */
+	if (eventfd_write(evfd, val) == -1)
+		test_fatal("eventfd_write()");
+
+	test_equal(epoll_wait(efd, &ev, 1, 0), 1);
+	test_equal(ev.events, EPOLLIN);
+	test_equal(ev.data.fd, evfd);
+
+	test_done();
+}


### PR DESCRIPTION
### OmniOS

```
build:epoll-test-suite:eventfd% uname -a
SunOS build 5.11 omnios-r151050-6f87d0b5d63 i86pc i386 i86pc
build:epoll-test-suite:eventfd% ./test_eventfd_et
test_eventfd_et 0       TPASS
test_eventfd_et 1       TPASS
test_eventfd_et 2       TFAIL: 0 != 1
```

### Ubuntu

```
ubuntu@viktor:~/epoll-test-suite/functional$ uname -a
Linux viktor 6.6.0-14-generic #14-Ubuntu SMP PREEMPT_DYNAMIC Thu Nov 30 10:27:29 UTC 2023 x86_64 x86_64 x86_64 GNU/Linux
ubuntu@viktor:~/epoll-test-suite/functional$ ./test_eventfd_et
test_eventfd_et	0	TPASS
test_eventfd_et	1	TPASS
test_eventfd_et	2	TPASS
```